### PR TITLE
Allow for different domains - Added optional domain parameter for Client

### DIFF
--- a/lib/exactonline.js
+++ b/lib/exactonline.js
@@ -13,11 +13,14 @@ var services = [
 /**
  * Client
  * @param  {Object} options  Options object
+ * @param  {string} domain   Options URL domain
  * @return {Client}          Returns itself
  */
-var Client = function(options) {
+var Client = function(options, domain) {
 
   var self = this;
+
+  var domain = domain || 'nl';
 
   // Defaults
   var defaults = {
@@ -48,7 +51,7 @@ var Client = function(options) {
   this.division = null;
 
   // Define API url
-  this.apiUrl = 'start.exactonline.nl';
+  this.apiUrl = 'start.exactonline.' + domain;
 
   // Loop services from array
   services.forEach(function(service) {


### PR DESCRIPTION
Allow the usage of other Exact Online URLs besides start.exactonline.nl.

Example:
```javascript
exactOnline.createClient(
{
  clientId: '12345',
   clientSecret: '6789',
   redirectUri: 'http://redirect.be'
}, 'be');
```
will result in apiUrl being set to 'start.exactonline.be'.
If no domain parameter is passed, it will default to 'nl'.
